### PR TITLE
Fetch and prune

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -14,6 +14,7 @@
   lp = log -p
   lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
   sd = !git diff stash@{0} `git rev-parse --abbrev-ref HEAD`
+  fp = fetch -p
   review = !GIT_CURRENT_BRANCH=$(git name-rev --name-only HEAD) && git log -p origin/$GIT_CURRENT_BRANCH..$GIT_CURRENT_BRANCH
   winners = shortlog --numbered --summary
   fakeignore = update-index --assume-unchanged


### PR DESCRIPTION
[git fetch -p](https://www.kernel.org/pub/software/scm/git/docs/git-fetch.html)
> After fetching, remove any remote-tracking references that no longer exist on the remote. Tags are not subject to pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example if the remote was cloned with the --mirror option), then they are also subject to pruning.