### PR TITLE
Open Github from terminal

### DIFF
--- a/bin/gh
+++ b/bin/gh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Opens the Github page for a repo/branch in your browser.
+#
+# gh [remote] [branch]
+
+git rev-parse 2>/dev/null
+
+if [[ $? != 0 ]]
+then
+  echo "Not a git repository."
+  exit 1
+fi
+
+remote="origin"
+if [ ! -z "$1" ]
+then
+  remote="$1"
+fi
+
+remote_url="remote.${remote}.url"
+
+giturl=$(git config --get $remote_url)
+if [ -z "$giturl" ]
+then
+  echo "$remote_url not set."
+  exit 1
+fi
+
+giturl=${giturl/git\@github\.com\:/https://github.com/}
+giturl=${giturl%\.git}
+
+if [ -z "$2" ]
+then
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+else
+  branch="$2"
+fi
+
+if [ ! -z "$branch" ]
+then
+  giturl="${giturl}/tree/${branch}"
+fi
+
+open $giturl
+exit 0


### PR DESCRIPTION
Borrowed from : https://github.com/jasonmccreary/gh
# gh

A command-line script to open the GitHub page for a repository.
## Usage

```
gh [remote-name] [branch-name]
```
### Examples

```
$ gh
> open https://github.com/REMOTE_ORIGIN_USER/CURRENT_REPO/tree/CURRENT_BRANCH

$ gh upstream
> open https://github.com/REMOTE_UPSTREAM_USER/CURRENT_REPO/tree/CURRENT_BRANCH

$ gh upstream master
> open https://github.com/REMOTE_UPSTREAM_USER/CURRENT_REPO/tree/master
```
