### PR TITLE
Sort tag by version (git tag -l)

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -56,3 +56,5 @@
   singlekey = true
 [rerere]
   enabled = true
+[tag]
+  sort = version:refname


### PR DESCRIPTION
Tags could also be sorted eg. `--sort=committerdate` but it could be a old tag is pushed as a newer (edge-case but).