### PR TITLE
Disable ZSH warning on macOS

### DIFF
--- a/files/bash_profile
+++ b/files/bash_profile
@@ -1,1 +1,4 @@
+# Disable ZSH warning on macOS
+export BASH_SILENCE_DEPRECATION_WARNING=1
+
 source ~/.dotfiles/files/bashrc


### PR DESCRIPTION
Remove warning about ZSH: https://www.infosecmonkey.com/2019/10/11/removing-the-zsh-warning-on-macos-catalina/